### PR TITLE
Testing for Milestone 2

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -14,7 +14,7 @@ import Data.Bool (Bool(False))
 import Game
 import FileIO
 import FileIO (loadGame)
-import PrettyIO (prettyGame, prettyBoard)
+import PrettyIO
 import GHC.IO.Exception (userError)
 -- import Data.ByteString (putStrLn)
 import Data.List.Split
@@ -98,6 +98,9 @@ main = do
     else if optPrint opts /= ""
     then do printIO (optPrint opts)
 
+    else if optWin opts
+    then do winIO file
+
     --CHECKS FOR MOVE IO -- THEN MAKES THE MOVE
     else if optMove opts /= ""
     then do moveIO (optMove opts) file
@@ -133,7 +136,11 @@ moveIO str file =
             Just z -> do putStrLn $ prettyBoard z
             Nothing -> do ioError $ userError "move could not be made!"
 
-    
+winIO :: FilePath -> IO()
+winIO file =
+    do
+        game <- loadGame file
+        ioGame game
 
 defaultIO :: String -> IO()
 defaultIO x =

--- a/Testing.hs
+++ b/Testing.hs
@@ -79,7 +79,7 @@ milestoneOne =
                 winner (([(z,miniTie) | z <- [0..7]]),(X,4)) `shouldBe` Going
         describe "Legal moves" $ do
             it "Full board of X's" $ do
-                legalMoves (testBoardX,(X,0))  `shouldBe` []
+                legalMoves (testBoardXmak,(X,0))  `shouldBe` []
             it "Empty board unrestrained" $ do
                 legalMoves ([],(X,9))  `shouldBe` [(x,y) | x <- [0..8], y <- [0..8]]
             it "Empty board top left" $ do
@@ -108,13 +108,14 @@ milestoneTwo =
                 readGame "XXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nO\n8" `shouldBe` (testBoardX,(O,8))
             it "full board shouldn't be empty" $ do
                 readGame "XXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nXXXXXXXXX\nO\n8" `shouldNotBe` ([],(O,8))
-        -- describe "Who Wins" $ do
-        --     it "diagonal of X's on X's turn" $ do
-        --         whoWins ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(O,8)) `shouldBe` Win X
-        --     it "horizontal of X's on X's turn" $ do
-        --         whoWins ([(0,[(0,X),(1,X),(2,X)]), (4,[(0,X),(1,X),(2,X)]), (8,[(0,X),(1,X)])],(O,8)) `shouldBe` Win X
-        --     it "diagonal of X's with forced win for X" $ do
-        --         whoWins forceWinX  `shouldBe` Win X
+        describe "Who Wins" $ do
+            it "diagonal of X's on X's turn" $ do
+                whoWins ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(X,8)) `shouldBe` Win X
+            it "horizontal of X's on X's turn" $ do
+                whoWins ([(0,[(0,X),(1,X),(2,X)]), (4,[(0,X),(1,X),(2,X)]), (8,[(0,X),(1,X)])],(X,8)) `shouldBe` Win X
+            it "diagonal of X's with forced win for X" $ do
+                whoWins forceWinX  `shouldBe` Win X
+            
 
 runTests :: IO()
 runTests =   

--- a/Testing.hs
+++ b/Testing.hs
@@ -121,6 +121,8 @@ milestoneTwo =
                 whoWins ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` Win X
             it "diagonal of X's with forced win for X" $ do
                 whoWins forceWinX  `shouldBe` Win X
+            it "force game middle" $ do
+                whoWins (fillBoardDiagonalX ++ [(8,[(0,X),(4,O),(8,X)])], (X,8)) `shouldBe` Win X
         describe "Best Move" $ do
             it "diagonal of X's on X's turn" $ do
                 bestMove ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(X,8)) `shouldBe` (8,8)

--- a/Testing.hs
+++ b/Testing.hs
@@ -131,7 +131,7 @@ milestoneTwo =
             it "vertical of X's on X's turn" $ do
                 bestMove ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` (6,2)
             it "force game middle" $ do
-                fillBoardDiagonalX ++ 
+                bestMove (fillBoardDiagonalX ++ [(8,[(0,X),(4,O),(8,X)])], (X,8)) `shouldSatisfy` (\x -> x `elem` [(8,2),(8,6)])
 
 runTests :: IO()
 runTests =   

--- a/Testing.hs
+++ b/Testing.hs
@@ -121,8 +121,14 @@ milestoneTwo =
                 whoWins ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` Win X
             it "diagonal of X's with forced win for X" $ do
                 whoWins forceWinX  `shouldBe` Win X
+            it "top left tie" $ do
+                whoWins ([(0,[(0,X),(1,X),(2,O),(3,O),(4,O),(5,X),(6,X),(7,X),(8,O)]),(6,[(0,X),(1,X),(2,X)]),(7,[(0,X),(2,X),(6,X),(8,X)]), (8,[(0,X),(2,X),(6,X),(8,X)])],(X,8)) `shouldBe` Win X
             it "force game middle" $ do
                 whoWins (fillBoardDiagonalX ++ [(8,[(0,X),(4,O),(8,X)])], (X,8)) `shouldBe` Win X
+            it "three corners" $ do
+                whoWins (fillBoardDiagonalX ++ [(8,[(0,X),(2,X),(8,X)])], (X,8)) `shouldBe` Win X
+            it "x corner start" $ do
+                whoWins (fillBoardDiagonalX ++ [(8,[(0,X),(7,O)])], (X,8)) `shouldBe` Win X
         describe "Best Move" $ do
             it "diagonal of X's on X's turn" $ do
                 bestMove ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(X,8)) `shouldBe` (8,8)
@@ -132,6 +138,8 @@ milestoneTwo =
                 bestMove ([(0,[(0,X),(1,X),(2,X)]),(1,[(0,X),(1,X),(2,X)]),(2,[(0,X),(1,X)])],(X,2)) `shouldBe` (2,2)
             it "vertical of X's on X's turn" $ do
                 bestMove ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` (6,2)
+            it "top left tie" $ do
+                bestMove ([(0,[(0,X),(1,X),(2,O),(3,O),(4,O),(5,X),(6,X),(7,X),(8,O)]),(6,[(0,X),(1,X),(2,X)]),(7,[(0,X),(2,X),(6,X),(8,X)]), (8,[(0,X),(2,X),(6,X),(8,X)])],(X,8)) `shouldSatisfy` (\x -> x `elem` [(8,1),(8,3),(8,4),(8,5),(8,7)])
             it "three corners" $ do
                 bestMove (fillBoardDiagonalX ++ [(8,[(0,X),(2,X),(8,X)])], (X,8)) `shouldSatisfy` (\x -> x `elem` [(8,1),(8,5)])
             it "x corner start" $ do

--- a/Testing.hs
+++ b/Testing.hs
@@ -18,6 +18,7 @@ import Data.Maybe (Maybe(Nothing))
 import Data.Bool (Bool(True))
 import PrettyIO
 import Solver
+import Solver (bestMove)
 
 -- when some are filled in feel free to comment ot tests here
 testBoardOne = [(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X),(8,X)])]
@@ -42,6 +43,7 @@ singleBotRight = [(z,[(0,X)]) | z <- [0..8]]
 
 forceWinX =  ([(0,[(0,X),(1,X),(2,X)]),(4,[(0,X),(1,X),(2,X)]), (8,[(0,X),(2,X),(8,X)])] ++ [(x,[(0,O),(1,O),(2,O)]) | x <- [1,2,3,5,6,7]],(X,8))
 
+fillBoardDiagonalX = [(0,[(0,X),(1,X),(2,X)]),(4,[(0,X),(1,X),(2,X)])] ++ [(x,[(0,O),(1,O),(2,O)]) | x <- [1,2,3,5,6,7]]
 
 milestoneOne =
     do
@@ -79,7 +81,7 @@ milestoneOne =
                 winner (([(z,miniTie) | z <- [0..7]]),(X,4)) `shouldBe` Going
         describe "Legal moves" $ do
             it "Full board of X's" $ do
-                legalMoves (testBoardXmak,(X,0))  `shouldBe` []
+                legalMoves (testBoardX,(X,0))  `shouldBe` []
             it "Empty board unrestrained" $ do
                 legalMoves ([],(X,9))  `shouldBe` [(x,y) | x <- [0..8], y <- [0..8]]
             it "Empty board top left" $ do
@@ -113,9 +115,23 @@ milestoneTwo =
                 whoWins ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(X,8)) `shouldBe` Win X
             it "horizontal of X's on X's turn" $ do
                 whoWins ([(0,[(0,X),(1,X),(2,X)]), (4,[(0,X),(1,X),(2,X)]), (8,[(0,X),(1,X)])],(X,8)) `shouldBe` Win X
+            it "horizontal of X's on X's turn" $ do
+                whoWins ([(0,[(0,X),(1,X),(2,X)]),(1,[(0,X),(1,X),(2,X)]),(2,[(0,X),(1,X)])],(X,2)) `shouldBe` Win X
+            it "vertical of X's on X's turn" $ do
+                whoWins ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` Win X
             it "diagonal of X's with forced win for X" $ do
                 whoWins forceWinX  `shouldBe` Win X
-            
+        describe "Best Move" $ do
+            it "diagonal of X's on X's turn" $ do
+                bestMove ([(0,[(0,X),(4,X),(8,X)]), (4,[(0,X),(4,X),(8,X)]), (8,[(0,X),(4,X)])],(X,8)) `shouldBe` (8,8)
+            it "horizontal of X's on X's turn" $ do
+                bestMove ([(0,[(0,X),(1,X),(2,X)]), (4,[(0,X),(1,X),(2,X)]), (8,[(0,X),(1,X)])],(X,8)) `shouldBe` (8,2)
+            it "horizontal of X's on X's turn" $ do
+                bestMove ([(0,[(0,X),(1,X),(2,X)]),(1,[(0,X),(1,X),(2,X)]),(2,[(0,X),(1,X)])],(X,2)) `shouldBe` (2,2)
+            it "vertical of X's on X's turn" $ do
+                bestMove ([(0,[(0,X),(1,X),(2,X)]),(3,[(0,X),(1,X),(2,X)]),(6,[(0,X),(1,X)])],(X,6)) `shouldBe` (6,2)
+            it "force game middle" $ do
+                fillBoardDiagonalX ++ 
 
 runTests :: IO()
 runTests =   


### PR DESCRIPTION
Implemented test cases for Milestone 2.
Seth & Hugh

Cases range from a depth of 1 to larger.

All types are now up to Fogarty standard, with **makeMove**, **winner** and **legalMoves** now taking **Game**'s

The IO was added to work for printing the best next move, dependent on the **bestMove** function.